### PR TITLE
execute neoshell command via ssh

### DIFF
--- a/server/sshsvr/sshd/sshd.go
+++ b/server/sshsvr/sshd/sshd.go
@@ -41,6 +41,8 @@ type Shell struct {
 	Envs map[string]string
 }
 
+type CommandParser func(user string, cmd []string) []string
+
 // message of the day provider
 type MotdProvider func(user string) string
 
@@ -57,6 +59,7 @@ type Server interface {
 
 	SetHandler(handler ssh.Handler)
 	SetShellProvider(provider ShellProvider)
+	SetCommandParser(parser CommandParser)
 	SetMotdProvider(provider MotdProvider)
 	SetPasswordHandler(func(ctx ssh.Context, password string) bool)
 	SetPublicKeyHandler(func(ctx ssh.Context, key ssh.PublicKey) bool)
@@ -74,6 +77,7 @@ type server struct {
 	svr           *ssh.Server
 	alive         bool
 	shellProvider ShellProvider
+	commandParser CommandParser
 	motdProvider  MotdProvider
 	childrenLock  sync.Mutex
 	children      map[int]*os.Process
@@ -187,6 +191,10 @@ func (svr *server) SetShellProvider(provider ShellProvider) {
 	svr.shellProvider = provider
 }
 
+func (svr *server) SetCommandParser(parser CommandParser) {
+	svr.commandParser = parser
+}
+
 func (svr *server) SetMotdProvider(provider MotdProvider) {
 	svr.motdProvider = provider
 }
@@ -292,6 +300,9 @@ func (svr *server) defaultHandler(ss ssh.Session) {
 
 func (svr *server) commandHandler(ss ssh.Session) {
 	cmdArr := ss.Command()
+	if svr.commandParser != nil {
+		cmdArr = svr.commandParser(ss.User(), cmdArr)
+	}
 	if len(cmdArr) == 0 {
 		io.WriteString(ss, "Invalid Command\n")
 		ss.Exit(1)

--- a/server/sshsvr/sshsvr.go
+++ b/server/sshsvr/sshsvr.go
@@ -36,14 +36,24 @@ type MachShell struct {
 	gitSHA        string
 	editionString string
 
+	shellCmd []string
+
 	Server Server // injection point
 }
 
 func New(db spi.Database, conf *Config) *MachShell {
-	return &MachShell{
+	sh := &MachShell{
 		conf: conf,
 		db:   db,
 	}
+	if len(os.Args) > 0 {
+		sh.shellCmd = []string{os.Args[0]}
+
+		if strings.HasSuffix(sh.shellCmd[0], "machbase-neo") {
+			sh.shellCmd = append(sh.shellCmd, "shell")
+		}
+	}
+	return sh
 }
 
 func (svr *MachShell) Start() error {
@@ -76,6 +86,7 @@ func (svr *MachShell) Start() error {
 			return errors.Wrap(err, "machsell")
 		}
 		s.SetShellProvider(svr.shellProvider)
+		s.SetCommandParser(svr.commandParser)
 		s.SetMotdProvider(svr.motdProvider)
 		s.SetPasswordHandler(svr.passwordProvider)
 		s.SetPublicKeyHandler(svr.publicKeyProvider)
@@ -96,19 +107,34 @@ func (svr *MachShell) Stop() {
 	}
 }
 
-func (svr *MachShell) shellProvider(user string) *sshd.Shell {
+func (svr *MachShell) makeShellCommand(user string, args ...string) []string {
 	grpcAddrs := svr.Server.GetGrpcAddresses()
 	if len(grpcAddrs) == 0 {
 		return nil
 	}
-	return &sshd.Shell{
-		Cmd: os.Args[0],
-		Args: []string{
-			"shell",
-			"--server", grpcAddrs[0],
-			"--user", user,
-		},
+	result := append(svr.shellCmd,
+		"--server", grpcAddrs[0],
+		"--user", user,
+	)
+	if len(args) > 0 {
+		result = append(result, args...)
 	}
+	return result
+}
+
+func (svr *MachShell) shellProvider(user string) *sshd.Shell {
+	parsed := svr.makeShellCommand(user)
+	if len(parsed) == 0 {
+		return nil
+	}
+	return &sshd.Shell{
+		Cmd:  parsed[0],
+		Args: parsed[1:],
+	}
+}
+
+func (svr *MachShell) commandParser(user string, cmd []string) []string {
+	return svr.makeShellCommand(user, cmd...)
 }
 
 func (svr *MachShell) motdProvider(user string) string {


### PR DESCRIPTION
Execute neoshell command remotely via ssh

```sh
$ ssh -p 5652 sys@127.0.0.1 'select count(*) from example'  ↵
 ROWNUM  COUNT(*) 
──────────────────
 1       1698     
```

```
$ssh -p 5652 sys@127.0.0.1 'show info'   ↵
┌────────────────────┬─────────────────────────┐
│ NAME               │ VALUE                   │
├────────────────────┼─────────────────────────┤
│ build.version      │ v0.2.3                  │
│ build.hash         │ #c3853a4                │
│ build.timestamp    │ 2023-02-18T09:20:33     │
│ build.engine       │ static_fog_darwin_arm64 │
│ runtime.os         │ darwin                  │
│ runtime.arch       │ arm64                   │
......
```