### PR TITLE
remove implicit query timeout machbase/neo#15

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -88,7 +88,7 @@ func DefaultConfig() *Config {
 		PromptCont:   "\033[37m>\033[0m  ",
 		HistoryFile:  "/tmp/readline.tmp",
 		VimMode:      false,
-		QueryTimeout: 30 * time.Second,
+		QueryTimeout: 0 * time.Second,
 		Lang:         language.English,
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/machbase/booter v1.1.0
-	github.com/machbase/neo-grpc v0.2.1-0.20230217143638-fc055a0f44bd
+	github.com/machbase/neo-grpc v0.2.1-0.20230218062400-d7c1813e0573
 	github.com/machbase/neo-logging v1.0.0
 	github.com/machbase/neo-spi v0.0.0-20230215102041-ce33f66f46e0
 	github.com/mum4k/termdash v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/machbase/booter v1.1.0 h1:xLY3EdxIwHz8qAMnZMyyFqkHEVAFEbySyzJC1RLHAFI=
 github.com/machbase/booter v1.1.0/go.mod h1:XIvfrgM0bDDmbjvD1s/4UVYyCoVbjTXAvX2V645EXIg=
-github.com/machbase/neo-grpc v0.2.1-0.20230217143638-fc055a0f44bd h1:Vq1xFSSCrFgypCNi5lze1GoaKKJl4sGdOWw0RCP1zTA=
-github.com/machbase/neo-grpc v0.2.1-0.20230217143638-fc055a0f44bd/go.mod h1:57lwEEA+Kk4hkMt0q8lhnSzKebUh1ljVVbqP9CKD+uE=
+github.com/machbase/neo-grpc v0.2.1-0.20230218062400-d7c1813e0573 h1:/F+g0bLt69XI1aH7LGW5ss3bmmQ2fkvoA8vdJdWDL88=
+github.com/machbase/neo-grpc v0.2.1-0.20230218062400-d7c1813e0573/go.mod h1:57lwEEA+Kk4hkMt0q8lhnSzKebUh1ljVVbqP9CKD+uE=
 github.com/machbase/neo-logging v1.0.0 h1:5VarIDHLK9Un++Uy3KD9P+MceevQYZPV+mxYo+5GwB0=
 github.com/machbase/neo-logging v1.0.0/go.mod h1:Yzuw+yZ00TADBxsZg1u21weHx+/OtmyoAdApM1TG0tU=
 github.com/machbase/neo-spi v0.0.0-20230215102041-ce33f66f46e0 h1:EBQipMuNb+3tkoxT411fDYvUCMeLXVLynb+mck6S9JI=


### PR DESCRIPTION
fix timeout problem when executing long-run-query. which leads gRPC timeout first while query is still running.

