### PR TITLE
client key generation & management

### DIFF
--- a/internal/cmd/key.go
+++ b/internal/cmd/key.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -27,6 +28,8 @@ const helpKey = `  key command [options] [args...]
       list        list registered keys
       del <id>    delete key
       gen <id>    generate new key with given id
+    options:
+      --output,-o <file>   output file (default:'-' stdout)
 `
 
 type KeyCmd struct {
@@ -35,7 +38,8 @@ type KeyCmd struct {
 		KeyId string `arg:"" name:"id"`
 	} `cmd:"" name:"del"`
 	Gen struct {
-		KeyId string `arg:"" name:"id"`
+		KeyId  string `arg:"" name:"id"`
+		Output string `name:"output" short:"o" default:"-" help:"store key and token files"`
 	} `cmd:"" name:"gen"`
 	Help bool `kong:"-"`
 }
@@ -64,7 +68,7 @@ func doKey(ctx *client.ActionContext) {
 	case "list":
 		doKeyList(ctx)
 	case "gen <id>":
-		doKeyGen(ctx, cmd.Gen.KeyId)
+		doKeyGen(ctx, cmd.Gen.KeyId, cmd.Gen.Output)
 	case "del <id>":
 		doKeyDel(ctx, cmd.Del.KeyId)
 	default:
@@ -119,7 +123,7 @@ func doKeyDel(ctx *client.ActionContext, id string) {
 	ctx.Println("deleted")
 }
 
-func doKeyGen(ctx *client.ActionContext, name string) {
+func doKeyGen(ctx *client.ActionContext, name string, output string) {
 	name = strings.ToLower(name)
 	pass, _ := regexp.MatchString("[a-z][a-z0-9_.@-]+", name)
 	if !pass {
@@ -147,11 +151,22 @@ func doKeyGen(ctx *client.ActionContext, name string) {
 		return
 	}
 
-	ctx.Println(rsp.Certificate)
-	ctx.Println(rsp.Key)
-	ctx.Println("-----BEGIN TOKEN-----")
-	ctx.Println(rsp.Token)
-	ctx.Println("-----END TOKEN-----")
-	ctx.Println("\nCaution:\n  This is the last chance to copy and store PRIVATE KEY and TOKEN.")
-	ctx.Println("  It can not be redo.")
+	if output == "-" {
+		ctx.Println(rsp.Certificate)
+		ctx.Println(rsp.Key)
+		ctx.Println("TOKEN", rsp.Token)
+		ctx.Println("\nCaution:\n  This is the last chance to copy and store PRIVATE KEY and TOKEN.")
+		ctx.Println("  It can not be redo.")
+	} else {
+		certfile := output + "_cert.pem"
+		keyfile := output + "_key.pem"
+		tokfile := output + "_token"
+
+		ctx.Println("Save certificate", certfile)
+		os.WriteFile(certfile, []byte(rsp.Certificate), 0644)
+		ctx.Println("Save private key", keyfile)
+		os.WriteFile(keyfile, []byte(rsp.Key), 0600)
+		ctx.Println("Save token", tokfile)
+		os.WriteFile(tokfile, []byte(rsp.Token), 0600)
+	}
 }


### PR DESCRIPTION
client side commands for key/token management

- gnerate : `neoshell key gen -o <output_file> <client_id>`


- list keys: `neoshell key list`
```
./tmp/neoshell key list                                   
┌────────┬───────────┬───────────────────────────────┬───────────────────────────────┐
│ ROWNUM │ ID        │ VALID FROM                    │ EXPIRE                        │
├────────┼───────────┼───────────────────────────────┼───────────────────────────────┤
│      1 │ test-app1 │ 2023-02-19 23:19:30 +0000 UTC │ 2033-02-16 23:19:30 +0000 UTC │
│      2 │ test-app2 │ 2023-02-20 00:12:26 +0000 UTC │ 2033-02-17 00:12:26 +0000 UTC │
│      3 │ test-app3 │ 2023-02-20 04:28:10 +0000 UTC │ 2033-02-17 04:28:10 +0000 UTC │
│      4 │ test-app4 │ 2023-02-20 04:30:50 +0000 UTC │ 2033-02-17 04:30:50 +0000 UTC │
│      5 │ test-app5 │ 2023-02-20 04:38:06 +0000 UTC │ 2033-02-17 04:38:06 +0000 UTC │
│      6 │ test-app6 │ 2023-02-20 05:15:16 +0000 UTC │ 2033-02-17 05:15:16 +0000 UTC │
└────────┴───────────┴───────────────────────────────┴───────────────────────────────┘
```

- delete keys: `neoshell key del <id>`

```
./tmp/neoshell key del test-app1
deleted
```