### PR TITLE
missing user message for result of sql statement

### DIFF
--- a/do/query.go
+++ b/do/query.go
@@ -1,6 +1,10 @@
 package do
 
-import spi "github.com/machbase/neo-spi"
+import (
+	"fmt"
+
+	spi "github.com/machbase/neo-spi"
+)
 
 type QueryContext struct {
 	DB           spi.Database
@@ -9,20 +13,20 @@ type QueryContext struct {
 	OnFetchEnd   func()
 }
 
-func Query(ctx *QueryContext, sqlText string, args ...any) error {
+func Query(ctx *QueryContext, sqlText string, args ...any) (string, error) {
 	rows, err := ctx.DB.Query(sqlText, args...)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer rows.Close()
 
 	if !rows.IsFetchable() {
-		return nil
+		return rows.Message(), nil
 	}
 
 	cols, err := rows.Columns()
 	if err != nil {
-		return err
+		return "", err
 	}
 	if ctx.OnFetchStart != nil {
 		ctx.OnFetchStart(cols)
@@ -36,12 +40,21 @@ func Query(ctx *QueryContext, sqlText string, args ...any) error {
 		rec := cols.MakeBuffer()
 		err = rows.Scan(rec...)
 		if err != nil {
-			return err
+			return "", err
 		}
 		nrow++
 		if ctx.OnFetch != nil && !ctx.OnFetch(nrow, rec) {
 			break
 		}
 	}
-	return nil
+
+	var usermsg = rows.Message()
+	if nrow == 0 {
+		usermsg = "no row fetched."
+	} else if nrow == 1 {
+		usermsg = "a row fetched."
+	} else {
+		usermsg = fmt.Sprintf("%d rows fetched.", nrow)
+	}
+	return usermsg, nil
 }

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -112,8 +112,10 @@ func doExport(ctx *client.ActionContext) {
 		},
 	}
 
-	err = do.Query(queryCtx, "select * from "+cmd.Table)
+	msg, err := do.Query(queryCtx, "select * from "+cmd.Table)
 	if err != nil {
 		ctx.Println("ERR", err.Error())
+	} else {
+		ctx.Println(msg)
 	}
 }

--- a/internal/cmd/sql.go
+++ b/internal/cmd/sql.go
@@ -157,9 +157,11 @@ func doSql(ctx *client.ActionContext) {
 	}
 
 	sqlText := util.StripQuote(strings.Join(cmd.Query, " "))
-	err = do.Query(queryCtx, sqlText)
+	msg, err := do.Query(queryCtx, sqlText)
 	if err != nil {
 		ctx.Println("ERR", err.Error())
+	} else {
+		ctx.Println(msg)
 	}
 	client.AddSqlHistory(sqlText)
 }

--- a/server/httpsvr/h_query.go
+++ b/server/httpsvr/h_query.go
@@ -114,8 +114,11 @@ func (svr *Server) handleQuery(ctx *gin.Context) {
 			encoder.Close()
 		},
 	}
-	if err := do.Query(queryCtx, req.SqlText); err != nil {
+	if msg, err := do.Query(queryCtx, req.SqlText); err != nil {
 		rsp.Reason = err.Error()
 		ctx.JSON(http.StatusInternalServerError, rsp)
+	} else {
+		rsp.Reason = msg
+		ctx.JSON(http.StatusOK, rsp)
 	}
 }


### PR DESCRIPTION
display result of sql statement execution.

```sh
$ machbase-neo shell sql " insert into example values ('wave.pi', now, 3.141592)"
a row inserted.
```

```sh
$ machbase-neo shell sql "select * from example"
 ......
 9005  wave.pi  2023-02-24 02:47:32.536  3.141592
 9006  wave.pi  2023-02-24 02:47:48.097  3.141592
9006 rows fetched.
```