### PR TITLE
sql, export support output in gzip compress

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"compress/gzip"
 	"time"
 
 	"github.com/chzyer/readline"
@@ -26,7 +27,10 @@ const helpExport = `  export [options] <table>
     table               table name to read
   options:
     --output,-o <file>   output file (default:'-' stdout)
-    --format,-f <format> output format [csv,json] (default:'csv')
+    --format,-f <format> output format
+      csv        csv format (default)
+      json       json format
+    --compress <method>  compression method [gzip] (default is not compressed)
     --[no-]header        export header (default:false)
     --delimiter,-d      csv delimiter (default:',')
     --tz                timezone for handling datetime
@@ -43,6 +47,7 @@ type ExportCmd struct {
 	Heading      bool           `name:"heading" negatable:""`
 	TimeLocation *time.Location `name:"tz" default:"UTC"`
 	Format       string         `name:"format" short:"f" default:"csv" enum:"box,csv,json"`
+	Compress     string         `name:"compress" default:"-" enum:"-,gzip"`
 	Delimiter    string         `name:"delimiter" short:"d" default:","`
 	TimeFormat   string         `name:"timeformat" short:"t" default:"ns"`
 	Precision    int            `name:"precision" short:"p" default:"-1"`
@@ -75,10 +80,25 @@ func doExport(ctx *client.ActionContext) {
 	}
 
 	var outputPath = util.StripQuote(cmd.Output)
-	output, err := stream.NewOutputStream(outputPath)
+	var output spi.OutputStream
+	output, err = stream.NewOutputStream(outputPath)
 	if err != nil {
 		ctx.Println("ERR", err.Error())
 		return
+	}
+	defer output.Close()
+
+	if cmd.Compress == "gzip" {
+		gw := gzip.NewWriter(output)
+		defer func() {
+			if gw != nil {
+				err := gw.Close()
+				if err != nil {
+					ctx.Println("ERR", err.Error())
+				}
+			}
+		}()
+		output = &stream.WriterOutputStream{Writer: gw}
 	}
 
 	encoder := codec.NewEncoderBuilder(cmd.Format).
@@ -108,7 +128,6 @@ func doExport(ctx *client.ActionContext) {
 		},
 		OnFetchEnd: func() {
 			encoder.Close()
-			output.Close()
 		},
 	}
 

--- a/internal/cmd/sql.go
+++ b/internal/cmd/sql.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"compress/gzip"
 	"fmt"
 	"os"
 	"strings"
@@ -35,6 +36,7 @@ const helpSql string = `  sql [options] <query>
 	  box        box format (default)
       csv        csv format
       json       json format
+    --compress <method>  compression method [gzip] (default is not compressed)
     --delimiter,-d       csv delimiter (default:',')
     --[no-]rownum        include rownum as first column (default:true)
     --timeformat,-t      time format [ns|ms|s|<timeformat>] (default:'default')
@@ -51,6 +53,7 @@ type SqlCmd struct {
 	Heading      bool           `name:"heading" negatable:"" default:"true"`
 	TimeLocation *time.Location `name:"tz" default:"UTC"`
 	Format       string         `name:"format" short:"f" default:"box" enum:"box,csv,json"`
+	Compress     string         `name:"compress" default:"-" enum:"-,gzip"`
 	Delimiter    string         `name:"delimiter" short:"d" default:","`
 	Rownum       bool           `name:"rownum" negatable:"" default:"true"`
 	TimeFormat   string         `name:"timeformat" short:"t" default:"default"`
@@ -83,15 +86,31 @@ func doSql(ctx *client.ActionContext) {
 	}
 
 	var outputPath = util.StripQuote(cmd.Output)
-	output, err := stream.NewOutputStream(outputPath)
+	var output spi.OutputStream
+	output, err = stream.NewOutputStream(outputPath)
 	if err != nil {
 		ctx.Println("ERR", err.Error())
 	}
+	defer output.Close()
 
-	if outputPath == "-" {
-		cmd.Interactive = ctx.Interactive
-	} else {
+	if cmd.Compress == "gzip" {
+		gw := gzip.NewWriter(output)
+		defer func() {
+			if gw != nil {
+				err := gw.Close()
+				if err != nil {
+					ctx.Println("ERR", err.Error())
+				}
+			}
+		}()
+		output = &stream.WriterOutputStream{Writer: gw}
 		cmd.Interactive = false
+	} else {
+		if outputPath == "-" {
+			cmd.Interactive = ctx.Interactive
+		} else {
+			cmd.Interactive = false
+		}
 	}
 
 	encoder := codec.NewEncoderBuilder(cmd.Format).


### PR DESCRIPTION
support gzip compress

```sh
machbase-neo shell sql --output example.txt.gz --format csv --compress gzip "select * from example"
```

```sh
machbase-neo shell export --output example.out.gz --compress gzip  example
```